### PR TITLE
Add basic product listing

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,10 @@
+# KX Backend
+
+API construida con [NestJS](https://nestjs.com/) y lista para conectarse a MongoDB.
+
+## Scripts
+
+- `npm start` – inicia el servidor en `http://localhost:3001`.
+
+Endpoints iniciales:
+- `GET /` responde con `{"message":"KX API"}`.

--- a/backend/app.controller.js
+++ b/backend/app.controller.js
@@ -1,0 +1,21 @@
+const { Controller, Get } = require('@nestjs/common');
+
+function AppController() {}
+
+AppController.prototype.getRoot = function () {
+  return { message: 'KX API' };
+};
+
+AppController.prototype.getProducts = function () {
+  return [
+    { id: 1, name: 'Producto 1', price: 19.99 },
+    { id: 2, name: 'Producto 2', price: 29.99 },
+    { id: 3, name: 'Producto 3', price: 39.99 },
+  ];
+};
+
+Controller()(AppController);
+Get()(AppController.prototype, 'getRoot', Object.getOwnPropertyDescriptor(AppController.prototype, 'getRoot'));
+Get('products')(AppController.prototype, 'getProducts', Object.getOwnPropertyDescriptor(AppController.prototype, 'getProducts'));
+
+module.exports.AppController = AppController;

--- a/backend/app.module.js
+++ b/backend/app.module.js
@@ -1,0 +1,8 @@
+const { Module } = require('@nestjs/common');
+const { AppController } = require('./app.controller');
+
+class AppModule {}
+
+module.exports.AppModule = Module({
+  controllers: [AppController],
+})(AppModule);

--- a/backend/main.js
+++ b/backend/main.js
@@ -1,0 +1,10 @@
+require('reflect-metadata');
+const { NestFactory } = require('@nestjs/core');
+const { AppModule } = require('./app.module');
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3001);
+  console.log('API escuchando en http://localhost:3001');
+}
+bootstrap();

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "kosxpress-backend",
+  "version": "0.1.0",
+  "main": "main.js",
+  "scripts": {
+    "start": "node main.js"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.3.0",
+    "@nestjs/core": "^10.3.0",
+    "@nestjs/platform-express": "^10.3.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.1"
+  }
+}

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,11 @@
+# KX Frontend
+
+Aplicación web creada con [Next.js](https://nextjs.org/) en JavaScript.
+
+## Scripts
+
+- `npm run dev` – inicia el servidor de desarrollo en `http://localhost:3000`.
+- `npm run build` – genera la versión de producción.
+- `npm start` – ejecuta la aplicación ya construida.
+
+Estilos gestionados con CSS tradicional. La apariencia inicial puede basarse en el diseño de [koscolombia.com](https://www.koscolombia.com/).

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "kosxpress-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "^14.2.5",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -1,0 +1,5 @@
+import '../styles/globals.css';
+
+export default function App({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,0 +1,11 @@
+export default function Home() {
+  return (
+    <main>
+      <h1>Bienvenido a KX</h1>
+      <p>Tienda virtual en construcción.</p>
+      <p>
+        <a href="/products">Ver productos</a>
+      </p>
+    </main>
+  );
+}

--- a/frontend/pages/products.js
+++ b/frontend/pages/products.js
@@ -1,0 +1,29 @@
+import Head from 'next/head';
+
+export async function getServerSideProps() {
+  try {
+    const res = await fetch('http://localhost:3001/products');
+    const products = await res.json();
+    return { props: { products } };
+  } catch {
+    return { props: { products: [] } };
+  }
+}
+
+export default function Products({ products }) {
+  return (
+    <>
+      <Head>
+        <title>Tienda KX</title>
+      </Head>
+      <main className="product-grid">
+        {products.map((p) => (
+          <div className="product-card" key={p.id}>
+            <h2>{p.name}</h2>
+            <p>${'{'}p.price{'}'}</p>
+          </div>
+        ))}
+      </main>
+    </>
+  );
+}

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,0 +1,21 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+}
+
+main {
+  padding: 2rem;
+  text-align: center;
+}
+
+.product-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.product-card {
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 1rem;
+}


### PR DESCRIPTION
## Summary
- add `/products` endpoint with sample data
- create Next.js products page and link from home
- style product grid for initial store view

## Testing
- `node backend/main.js` *(fails: Cannot find module 'reflect-metadata')*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5fec206848324bd0b6610da2ef7f4